### PR TITLE
Use fgetc/fputc instead of getc/putc

### DIFF
--- a/src/xxd.c
+++ b/src/xxd.c
@@ -261,9 +261,9 @@ error_exit(int ret, char* msg)
 }
 
 static int
-getc_or_die(FILE* fpi)
+fgetc_or_die(FILE* fpi)
 {
-  int c = getc(fpi);
+  int c = fgetc(fpi);
 
   if(c == EOF && ferror(fpi))
   {
@@ -274,9 +274,9 @@ getc_or_die(FILE* fpi)
 }
 
 static void
-putc_or_die(int c, FILE* fpo)
+fputc_or_die(int c, FILE* fpo)
 {
-  if(putc(c, fpo) == EOF)
+  if(fputc(c, fpo) == EOF)
   {
     perror_exit(3);
   }
@@ -331,7 +331,7 @@ skip_to_eol(FILE* fpi, int c)
 {
   while(c != '\n' && c != EOF)
   {
-    c = getc_or_die(fpi);
+    c = fgetc_or_die(fpi);
   }
 
   return c;
@@ -365,7 +365,7 @@ huntype(
 
   int c;
 
-  while((c = getc(fpi)) != EOF)
+  while((c = fgetc(fpi)) != EOF)
   {
     if(c == '\r')  /* Doze style input file? */
     {
@@ -427,13 +427,13 @@ huntype(
 
       for(; have_off < base_off + want_off; have_off++)
       {
-        putc_or_die(0, fpo);
+        fputc_or_die(0, fpo);
       }
     }
 
     if(n2 >= 0 && n1 >= 0)
     {
-      putc_or_die((n2 << 4) | n1, fpo);
+      fputc_or_die((n2 << 4) | n1, fpo);
       have_off++;
       want_off++;
       n1 = -1;
@@ -1008,7 +1008,7 @@ main(int argc, char* argv[])
       long s = seekoff;
 
       while(s--)
-        if(getc_or_die(fp) == EOF)
+        if(fgetc_or_die(fp) == EOF)
         {
           error_exit(4, "Sorry, cannot seek.");
         }
@@ -1027,7 +1027,7 @@ main(int argc, char* argv[])
 
       for(e = 0; (c = varname[e]) != 0; e++)
       {
-        putc_or_die(isalnum(c) ? CONDITIONAL_CAPITALIZE(c) : '_', fpo);
+        fputc_or_die(isalnum(c) ? CONDITIONAL_CAPITALIZE(c) : '_', fpo);
       }
 
       fputs_or_die("[] = {\n", fpo);
@@ -1035,7 +1035,7 @@ main(int argc, char* argv[])
 
     p = 0;
 
-    while((length < 0 || p < length) && (c = getc_or_die(fp)) != EOF)
+    while((length < 0 || p < length) && (c = fgetc_or_die(fp)) != EOF)
     {
       FPRINTF_OR_DIE((fpo, (hexx == hexxa) ? "%s0x%02x" : "%s0X%02X",
                       (p % cols) ? ", " : (!p ? "  " : ",\n  "), c));
@@ -1054,7 +1054,7 @@ main(int argc, char* argv[])
 
       for(e = 0; (c = varname[e]) != 0; e++)
       {
-        putc_or_die(isalnum(c) ? CONDITIONAL_CAPITALIZE(c) : '_', fpo);
+        fputc_or_die(isalnum(c) ? CONDITIONAL_CAPITALIZE(c) : '_', fpo);
       }
 
       FPRINTF_OR_DIE((fpo, "_%s = %d;\n", capitalize ? "LEN" : "len", p));
@@ -1068,10 +1068,10 @@ main(int argc, char* argv[])
   {
     p = cols;
 
-    while((length < 0 || n < length) && (e = getc_or_die(fp)) != EOF)
+    while((length < 0 || n < length) && (e = fgetc_or_die(fp)) != EOF)
     {
-      putc_or_die(hexx[(e >> 4) & 0xf], fpo);
-      putc_or_die(hexx[e & 0xf], fpo);
+      fputc_or_die(hexx[(e >> 4) & 0xf], fpo);
+      fputc_or_die(hexx[e & 0xf], fpo);
       n++;
 
       if(cols > 0)
@@ -1080,7 +1080,7 @@ main(int argc, char* argv[])
 
         if(!p)
         {
-          putc_or_die('\n', fpo);
+          fputc_or_die('\n', fpo);
           p = cols;
         }
       }
@@ -1088,7 +1088,7 @@ main(int argc, char* argv[])
 
     if(cols == 0 || p < cols)
     {
-      putc_or_die('\n', fpo);
+      fputc_or_die('\n', fpo);
     }
 
     fclose_or_die(fp, fpo);
@@ -1106,7 +1106,7 @@ main(int argc, char* argv[])
     grplen = 8 * octspergrp + 1;
   }
 
-  while((length < 0 || n < length) && (e = getc_or_die(fp)) != EOF)
+  while((length < 0 || n < length) && (e = fgetc_or_die(fp)) != EOF)
   {
     int x;
 


### PR DESCRIPTION
This fixes a bug where sometimes line feeds 0x0A '\n' get an additional friend carriage return 0x0D '\r' (sometimes two) with them on Windows when reading/writing files.

Even without the bug, it's good form to use the same function family for all the operations, `fopen()`, `fread()`, `fclose()`; or `open()`, `read()`, `close()`; etc. and to not mix them even if mixing works fine in most situations.

#### More information at length, not required to read below this point

This is because in the current universal CRT version `getc()` doesn't always honor the mode set in the file handle but uses the one set by the CRT initialization stub which is dependent on your terminal and it's session (what programs were you running before and what the mode was last set to, etc.). This is most likely not intended behaviour and just one of many bugs in the modern Windows UCRT, or in Windows Terminal, or both.

The root culprit is probably one of these functions:
`api-ms-win-crt-stdio-l1-1-0.dll:_setmode()`
which gets it's value from `api-ms-win-crt-stdio-l1-1-0.dll:__acrt_iob_func()`

or

`api-ms-win-crt-stdio-l1-1-0.dll:_set_fmode()`
which sets it to _O_TEXT (0x4000)

or maybe even

`api-ms-win-crt-runtime-l1-1-0.dll:_set_app_type()`

Of which I'm not certain is the one causing this, since I couldn't get this to reliably fail, only sometimes, dependent on what I was doing before in a certain terminal session.

Those calls are all part of the fluff added by the universal CRT. There are also other character-conversion related problems in it, namely UTF8 <> UTF16, which leads to problems in the std:: family functions and ASCII / WideChar versions of the CRT functions like `getc()` / `getwc()`. One such error was investigated in here in case you're interested: https://github.com/ggerganov/llama.cpp/issues/1010#issuecomment-1512264963

A later comment implies that this bug was fixed in a later commit to the Windows Terminal, but I wouldn't count on that. Also Windows Terminal is not the only command-line environment, and there are multiple other venues to launch command-line processes ranging from good ol cmd (which isn't Terminal) to PowerShell to telnet to remote administration via WinRM, etc. etc.

This is just one of the many reasons I like to avoid the "modern" universal CRT like the plague. Even though [Raymond Chen doesn't like you using it](https://devblogs.microsoft.com/oldnewthing/20140411-00/?p=1273), the tried-and-true MSVCRT.DLL works just fine. That can't be said about the new UCRT. Unfortunately in Microsoft's push for everyone to use the new UCRT, modern MSVC versions make it annoying to link against the old working CRT as there is no option for doing so.

MinGW on the other hand links against msvcrt.lib by default and thus works fine, but GCC in Windows comes with it's own pitfalls.

Ultimately the best way to make sure Windows works without bugs is to throw the CRT out of the window altogether, but this can be annoying when writing portable code since you'd need to write everything twice, once using the Windows API and then again for everything else, adding an ugly web of #ifdefs.

Luckily in this case it seems to be enough to just use `fgetc()` instead of `getc()` and not have to throw the whole CRT in the trash. At least the bug hasn't occured since I switched the commands.

Also the MSDN description of `getc()` is wrong
![image](https://github.com/ckormanyos/xxd/assets/13628128/18a02902-6ca5-48e9-88bc-ffc80ad9c8bd)
Maybe they once were the same, but now they are different functions in the universal CRT.
I can't be arsed to start digging through the disassembly of those UCRT dlls to figure out *how* they are different though.
I've already wasted enough energy dealing with the UCRT as-is.



